### PR TITLE
Api discovery time limit workaround

### DIFF
--- a/lib/cloudtuya.js
+++ b/lib/cloudtuya.js
@@ -2,7 +2,7 @@
 
 var request = require('request');
 const events = require("events");
-const REFRESHTIME = 5000;
+const REFRESHTIME = 305000;
 
 
 class TuayApi extends events.EventEmitter {
@@ -11,6 +11,7 @@ class TuayApi extends events.EventEmitter {
         this.lastMessage = '';
         this.connectionError = false;
         this.refreshIntervalId = null;
+		this.deviceCache = [];
         if (!username || !password || !countryCode || !bizType) {
             this.connectionError = true;
             this.lastMessage = 'Missing login email/pass/country code/ application';
@@ -116,7 +117,11 @@ class TuayApi extends events.EventEmitter {
             devices.forEach((device) => {
                 this.emit("device_updated", device);
             });
-        }
+			this.deviceCache = devices;
+        } 
+		else {
+			devices = this.deviceCache;
+		}
         return devices;
     }
 


### PR DESCRIPTION
This will keep the most recent response from the API and replaces it the next time the API call succeeds. 

