### PR TITLE
Fixed missing await in autocomplete function

### DIFF
--- a/app.js
+++ b/app.js
@@ -221,8 +221,8 @@ class TuyaCloudApp extends Homey.App {
         return this.operateDevice(args.scene.instanceId, 'turnOnOff', { value: '1' });
     }
 
-    _onSceneAutoComplete( query, args ) {
-        let scenes = this.getScenes();
+    async _onSceneAutoComplete( query, args ) {
+        let scenes = await this.getScenes();
         return Object.values(scenes).map(s => {
             return { instanceId: s.id, name: s.name };
         });

--- a/app.json
+++ b/app.json
@@ -137,7 +137,7 @@
       {
         "id": "setScene",
         "title": {
-          "en": "Set a mood"
+          "en": "Trigger a scene"
         },
         "args": [
           {


### PR DESCRIPTION
The autocomplete function was doing some logic on a Promise instead of the Promise result yielding no response at all. I've fixed this by awaiting the call to `getScenes`. In the mean time I've also renamed `Set a mood` to `Trigger a scene` which is a more appropriate name.