### PR TITLE
Heater/Thermostat: Added temperature scaling

### DIFF
--- a/drivers/heater/device.js
+++ b/drivers/heater/device.js
@@ -22,6 +22,10 @@ const homeyToTuyaModeMap = new Map([
 
 class TuyaHeaterDevice extends TuyaBaseDevice {
     onInit() {
+        this.scale = this.getData().scale;
+        if (this.scale == undefined){
+            this.scale = 1;
+        }
         this.lastKnowHomeyThermostatMode = 'off'
         this.initDevice(this.getData().id);
         this.updateCapabilities(this.get_deviceConfig().status);
@@ -33,7 +37,7 @@ class TuyaHeaterDevice extends TuyaBaseDevice {
         this.log("Heater capabilities changed by Homey: " + JSON.stringify(valueObj));
         try {
             if (valueObj.target_temperature != null) {
-                this.set_target_temperature(valueObj.target_temperature);
+                this.set_target_temperature(valueObj.target_temperature*Math.pow(10,this.scale));
             }
             if (valueObj.onoff != null) {
                 this.set_on_off(valueObj.onoff === true || valueObj.onoff === 1);
@@ -60,10 +64,10 @@ class TuyaHeaterDevice extends TuyaBaseDevice {
                     }
                     break;
                 case 'temp_set':
-                    this.normalAsync('target_temperature', status.value);
+                    this.normalAsync('target_temperature', status.value/Math.pow(10,this.scale));
                     break;
                 case 'temp_current':
-                    this.normalAsync('measure_temperature', status.value);
+                    this.normalAsync('measure_temperature', status.value/Math.pow(10,this.scale));
                     break;
                 case 'mode':
                     const homeyMode = tuyaToHomeyModeMap.get(status.value);

--- a/drivers/heater/driver.js
+++ b/drivers/heater/driver.js
@@ -10,12 +10,14 @@ class TuyaHeaterDriver extends TuyaBaseDriver {
 
     async onPairListDevices() {
         let devices = [];
+        let scale;
         if (!this.homey.app.isConnected()) {
             throw new Error("Please configure the app first.");
         }
         else {
             let heater = this.get_devices_by_type("heater");
             for (let tuyaDevice of Object.values(heater)) {
+                scale = 1;
                 let capabilities = [];
                 let capabilitiesOptions = {};
                 this.log("Add heater, device details:");
@@ -41,11 +43,13 @@ class TuyaHeaterDriver extends TuyaBaseDriver {
                             case "temp_set":
                                 values = JSON.parse(tuyaDevice.functions[i].values);
                                 capabilities.push("target_temperature");
+                                scale = values.scale;
                                 capabilitiesOptions["target_temperature"] = 
                                     {
-                                        "min": values.min,
-                                        "max": values.max,
-                                        "step": values.step
+                                        "min": values.min/Math.pow(10,values.scale),
+                                        "max": values.max/Math.pow(10,values.scale),
+                                        "step": values.step/Math.pow(10,values.scale),
+                                        "decimals": values.scale
                                     };
                                 break;
                             case "mode":
@@ -63,7 +67,8 @@ class TuyaHeaterDriver extends TuyaBaseDriver {
                 }
                 devices.push({
                     data: {
-                        id: tuyaDevice.id
+                        id: tuyaDevice.id,
+                        scale: scale
                     },
                     capabilities: capabilities,
                     capabilitiesOptions: capabilitiesOptions,

--- a/drivers/thermostat/device.js
+++ b/drivers/thermostat/device.js
@@ -23,6 +23,10 @@ const CAPABILITIES_SET_DEBOUNCE = 1000;
 class TuyaThermostatDevice extends TuyaBaseDevice {
     onInit() {
         // this.lastKnowHomeyThermostatMode = 'off'
+        this.scale = this.getData().scale;
+        if (this.scale == undefined){
+            this.scale = 1;
+        }
         this.initDevice(this.getData().id);
         this.updateCapabilities(this.get_deviceConfig().status);
         this.registerMultipleCapabilityListener(this.getCapabilities(), async (values, options) => {
@@ -33,7 +37,7 @@ class TuyaThermostatDevice extends TuyaBaseDevice {
         this.log("Thermostat capabilities changed by Homey: " + JSON.stringify(valueObj));
         try {
             if (valueObj.target_temperature != null) {
-                this.set_target_temperature(valueObj.target_temperature*10);
+                this.set_target_temperature(valueObj.target_temperature*Math.pow(10,this.scale));
             }
             if (valueObj.onoff != null) {
                 this.set_on_off(valueObj.onoff === true || valueObj.onoff === 1);
@@ -60,10 +64,10 @@ class TuyaThermostatDevice extends TuyaBaseDevice {
                     // }
                     break;
                 case 'temp_set':
-                    this.normalAsync('target_temperature', status.value/10);
+                    this.normalAsync('target_temperature', status.value/Math.pow(10,this.scale));
                     break;
                 case 'temp_current':
-                    this.normalAsync('measure_temperature', status.value/10);
+                    this.normalAsync('measure_temperature', status.value/Math.pow(10,this.scale));
                     break;
                 // case 'mode':
                 //     const homeyMode = tuyaToHomeyModeMap.get(status.value);

--- a/drivers/thermostat/driver.js
+++ b/drivers/thermostat/driver.js
@@ -10,12 +10,14 @@ class TuyaThermostatDriver extends TuyaBaseDriver {
 
     async onPairListDevices() {
         let devices = [];
+        let scale;
         if (!this.homey.app.isConnected()) {
             throw new Error("Please configure the app first.");
         }
         else {
             let heater = this.get_devices_by_type("thermostat");
             for (let tuyaDevice of Object.values(heater)) {
+                scale = 1;
                 let capabilities = [];
                 let capabilitiesOptions = {};
                 this.log("Add thermostat, device details:");
@@ -43,10 +45,12 @@ class TuyaThermostatDriver extends TuyaBaseDriver {
                                 capabilities.push("target_temperature");
                                 capabilitiesOptions["target_temperature"] = 
                                     {
-                                        "min": values.min/10,
-                                        "max": values.max/10,
-                                        "step": values.step/10
+                                        "min": values.min/Math.pow(10,values.scale),
+                                        "max": values.max/(10,values.scale),
+                                        "step": values.step/Math.pow(10,values.scale),
+                                        "decimals": values.scale
                                     };
+                                scale = values.scale;
                                 break;
                             // case "mode":
                             //     values = JSON.parse(tuyaDevice.functions[i].values);
@@ -63,7 +67,8 @@ class TuyaThermostatDriver extends TuyaBaseDriver {
                 }
                 devices.push({
                     data: {
-                        id: tuyaDevice.id
+                        id: tuyaDevice.id,
+                        scale: scale
                     },
                     capabilities: capabilities,
                     capabilitiesOptions: capabilitiesOptions,


### PR DESCRIPTION
Added temperature scaling.
On device pairing, the scale factor from device settings (Tuya) is stored in device data. This factor ist used to calculate the min/max/step values for capabilities and the temp_set/temp_curr values with *10^scale.

This change will break devices already added to homey which are using scale factor 0 currently (heater).
But this change will bring the flexibility, that every heater/thermostat can have their own scale factor. I think it's dependent on the definition from the facturer. The Duux Threesixty heater only support full °C values without decimals. Most other devices are using scale factor 1 what means 1 decimal place in temperature.