### PR TITLE
Heater/Thermostat: fix for data/store on pairing

### DIFF
--- a/drivers/heater/device.js
+++ b/drivers/heater/device.js
@@ -22,7 +22,7 @@ const homeyToTuyaModeMap = new Map([
 
 class TuyaHeaterDevice extends TuyaBaseDevice {
     onInit() {
-        this.scale = this.getData().scale;
+        this.scale = this.getStoreValue('scale');
         if (this.scale == undefined){
             this.scale = 1;
         }

--- a/drivers/heater/driver.js
+++ b/drivers/heater/driver.js
@@ -67,7 +67,9 @@ class TuyaHeaterDriver extends TuyaBaseDriver {
                 }
                 devices.push({
                     data: {
-                        id: tuyaDevice.id,
+                        id: tuyaDevice.id
+                    },
+                    store: {
                         scale: scale
                     },
                     capabilities: capabilities,

--- a/drivers/thermostat/device.js
+++ b/drivers/thermostat/device.js
@@ -23,7 +23,7 @@ const CAPABILITIES_SET_DEBOUNCE = 1000;
 class TuyaThermostatDevice extends TuyaBaseDevice {
     onInit() {
         // this.lastKnowHomeyThermostatMode = 'off'
-        this.scale = this.getData().scale;
+        this.scale = this.getStoreValue('scale');
         if (this.scale == undefined){
             this.scale = 1;
         }

--- a/drivers/thermostat/driver.js
+++ b/drivers/thermostat/driver.js
@@ -67,7 +67,9 @@ class TuyaThermostatDriver extends TuyaBaseDriver {
                 }
                 devices.push({
                     data: {
-                        id: tuyaDevice.id,
+                        id: tuyaDevice.id
+                    },
+                    store: {
                         scale: scale
                     },
                     capabilities: capabilities,


### PR DESCRIPTION
Moved scale parameter from data to store paramater on pairing.

I added the scale parameter to the data dictionary in pairing. This caused a "device not found" error in the app while searching the device using the driver.getDevice() function with {id: id} parameter (missing the scale for these devices.
It's fixed by using the store parameter. 

Affected devices have to be re-paired after updating the app.